### PR TITLE
Adding check if file exists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Don't use this Extension
 Almost surely, you should be using https://github.com/quicken/filefocus instead of this extension.
+
 This **fork** only adds a check to avoid adding files to a focus group of the files don't exist.
 
 All credit belongs to [quicken](https://github.com/quicken).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Don't use this Extension
+Almost surely, you should be using https://github.com/quicken/filefocus instead of this extension.
+This **fork** only adds a check to avoid adding files to a focus group of the files don't exist.
+
+All credit belongs to [quicken](https://github.com/quicken).
+
+
 # File Focus
 
 File Focus provides quick access to frequently accessed source code and configuration files. Multiple files in a focus group can be opened with a single click to quickly resume

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-focus",
-  "version": "1.4.2",
+  "version": "1.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "file-focus",
-      "version": "1.4.2",
+      "version": "1.5.4",
       "dependencies": {
         "uuid": "^8.3.2",
         "vscode-uri": "^3.0.3"

--- a/src/Group.ts
+++ b/src/Group.ts
@@ -1,4 +1,5 @@
 import { Uri } from "vscode";
+import * as fs from 'fs/promises';
 
 /**
  * A collection of resources that should be shown together are managed by a Group.
@@ -16,7 +17,7 @@ export class Group {
    */
   public readonly = false;
 
-  constructor(public readonly id: string) {}
+  constructor(public readonly id: string) { }
 
   /**
    * Retuns all resources (files and folders) that are associated with a group.
@@ -29,13 +30,19 @@ export class Group {
    * Add a resource (file/folder) to the group.
    * @param uri The vscode.URI of the resource.
    */
-  public addResource = (uri: Uri) => {
+  public addResource = async (uri: Uri) => {
     if (this._resourceContains(uri)) {
       return;
     }
-    this._resource.push(uri);
-  };
 
+    // Check if the file or folder at the URI's fsPath exists
+    try {
+      await fs.access(uri.fsPath);
+      this._resource.push(uri);
+    } catch (err) {
+      console.error(`The file or folder at ${uri.fsPath} does not exist`);
+    }
+  };
   /**
    * Remove a resource (file/folder) from the group.
    * @param uri


### PR DESCRIPTION
Partially solves https://github.com/quicken/filefocus/issues/8

This PR adds a check so that files are not added to a group if the files don't exist.  